### PR TITLE
Simplify urls to room name, e.g. WEH-4302

### DIFF
--- a/src/app/[[...slug]]/page.tsx
+++ b/src/app/[[...slug]]/page.tsx
@@ -70,7 +70,11 @@ const Page = ({ params, searchParams }: Props) => {
       } else {
         // at least floor level
         const buildingCode = code.split('-')[0];
-        const floorLevel = code.split('-')[1][0]; // assumes single digit floor level
+        const floorRegexStr = buildings[buildingCode].floors
+          .map((floor) => floor.toString())
+          .join('|');
+        const floorRegex = new RegExp(floorRegexStr);
+        const floorLevel = code.match(floorRegex)?.[0];
         const roomName = code.split('-')[1];
 
         const building = buildings[buildingCode];
@@ -82,7 +86,7 @@ const Page = ({ params, searchParams }: Props) => {
         }
 
         // validations on the floor level
-        if (!building.floors.includes(floorLevel)) {
+        if (!floorLevel || !building.floors.includes(floorLevel)) {
           router.push(buildingCode);
           return;
         }

--- a/src/app/[[...slug]]/page.tsx
+++ b/src/app/[[...slug]]/page.tsx
@@ -70,7 +70,8 @@ const Page = ({ params, searchParams }: Props) => {
       } else {
         // at least floor level
         const buildingCode = code.split('-')[0];
-        const floorLevel = code.split('-')[1];
+        const floorLevel = code.split('-')[1][0]; // assumes single digit floor level
+        const roomName = code.split('-')[1];
 
         const building = buildings[buildingCode];
 
@@ -87,9 +88,8 @@ const Page = ({ params, searchParams }: Props) => {
         }
 
         const floor = { buildingCode, level: floorLevel };
-        const roomId = params.slug[1];
 
-        if (!roomId) {
+        if (!roomName || roomName === floorLevel) {
           // up to floor level
           dispatch(selectBuilding(building));
           zoomOnObject(mapRef.current, building.shapes.flat());
@@ -97,7 +97,7 @@ const Page = ({ params, searchParams }: Props) => {
         } else {
           zoomOnRoom(
             mapRef.current,
-            roomId,
+            roomName,
             floor,
             buildings,
             floorPlanMap,
@@ -210,7 +210,7 @@ const Page = ({ params, searchParams }: Props) => {
     let url = window.location.origin + '/';
     if (selectedRoom) {
       const floor = selectedRoom.floor;
-      url += `${floor.buildingCode}-${floor.level}/${selectedRoom.id}`;
+      url += `${floor.buildingCode}-${selectedRoom.name}`;
     } else if (focusedFloor) {
       url += `${focusedFloor.buildingCode}`;
       url += `-${focusedFloor.level}`;

--- a/src/components/buildings/mapUtils.ts
+++ b/src/components/buildings/mapUtils.ts
@@ -7,7 +7,7 @@ import {
   setIsZooming,
   setShowRoomNames,
 } from '@/lib/features/uiSlice';
-import { Building, Floor, FloorPlanMap, Name, Room } from '@/types';
+import { Building, Floor, Room } from '@/types';
 import prefersReducedMotion from '@/util/prefersReducedMotion';
 
 const setIsZoomingAsync = (isZooming: boolean) => {

--- a/src/components/buildings/mapUtils.ts
+++ b/src/components/buildings/mapUtils.ts
@@ -21,38 +21,22 @@ const setIsZoomingAsync = (isZooming: boolean) => {
 
 export const zoomOnRoom = (
   map: mapkit.Map | null,
-  roomName: Name,
-  floor: Floor,
-  buildings: Record<string, Building> | null,
-  floorPlanMap: FloorPlanMap,
+  room: Room,
   dispatch: Dispatch<UnknownAction>,
 ) => {
-  if (!buildings || !map || !floorPlanMap) {
+  if (!map) {
     return;
   }
+  if (room) {
+    dispatch(selectRoom(room));
+    dispatch(setShowRoomNames(true));
+    dispatch(setFocusedFloor(room.floor));
 
-  if (floor) {
-    if (
-      floorPlanMap[floor.buildingCode] &&
-      floorPlanMap[floor.buildingCode][floor.level]
-    ) {
-      const floorPlan = floorPlanMap[floor.buildingCode][floor.level];
-      const room = Object.values(floorPlan).find(
-        (r: Room) => r.name === roomName,
-      );
-
-      if (room) {
-        dispatch(selectRoom(room));
-        dispatch(setShowRoomNames(true));
-        dispatch(setFocusedFloor(floor));
-
-        // zoom after finish setting the floor
-        setIsZoomingAsync(true)(dispatch).then(() => {
-          const points = floorPlan[room.id].coordinates;
-          zoomOnObject(map, points[0]);
-        });
-      }
-    }
+    // zoom after finish setting the floor
+    setIsZoomingAsync(true)(dispatch).then(() => {
+      const points = room.coordinates;
+      zoomOnObject(map, points[0]);
+    });
   }
 };
 

--- a/src/components/buildings/mapUtils.ts
+++ b/src/components/buildings/mapUtils.ts
@@ -7,7 +7,7 @@ import {
   setIsZooming,
   setShowRoomNames,
 } from '@/lib/features/uiSlice';
-import { Building, Floor, FloorPlanMap, ID } from '@/types';
+import { Building, Floor, FloorPlanMap, Name, Room } from '@/types';
 import prefersReducedMotion from '@/util/prefersReducedMotion';
 
 const setIsZoomingAsync = (isZooming: boolean) => {
@@ -21,7 +21,7 @@ const setIsZoomingAsync = (isZooming: boolean) => {
 
 export const zoomOnRoom = (
   map: mapkit.Map | null,
-  roomId: ID,
+  roomName: Name,
   floor: Floor,
   buildings: Record<string, Building> | null,
   floorPlanMap: FloorPlanMap,
@@ -37,17 +37,21 @@ export const zoomOnRoom = (
       floorPlanMap[floor.buildingCode][floor.level]
     ) {
       const floorPlan = floorPlanMap[floor.buildingCode][floor.level];
-      const room = floorPlan[roomId];
+      const room = Object.values(floorPlan).find(
+        (r: Room) => r.name === roomName,
+      );
 
-      dispatch(selectRoom(room));
-      dispatch(setShowRoomNames(true));
-      dispatch(setFocusedFloor(floor));
+      if (room) {
+        dispatch(selectRoom(room));
+        dispatch(setShowRoomNames(true));
+        dispatch(setFocusedFloor(floor));
 
-      // zoom after finish setting the floor
-      setIsZoomingAsync(true)(dispatch).then(() => {
-        const points = floorPlan[room.id].coordinates;
-        zoomOnObject(map, points[0]);
-      });
+        // zoom after finish setting the floor
+        setIsZoomingAsync(true)(dispatch).then(() => {
+          const points = floorPlan[room.id].coordinates;
+          zoomOnObject(map, points[0]);
+        });
+      }
     }
   }
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,6 @@
 import { Coordinate } from 'mapkit-react';
 
 export type ID = string;
-export type Name = string;
 
 export type BuildingCode = string;
 export type FloorLevel = string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@
 import { Coordinate } from 'mapkit-react';
 
 export type ID = string;
+export type Name = string;
 
 export type BuildingCode = string;
 export type FloorLevel = string;


### PR DESCRIPTION
# Description

Now instead of: https://maps.scottylabs.org/WEH-7/1af9af2c-f6a5-4e43-81cd-9b483c52ae39

We get: https://maps.scottylabs.org/WEH-7500

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

This is tested by finding the room on the map and seeing that the hyperlink matches the buildingCode-roomName and that when you access localhost:3000/buildingCode-roomName it goes to the correct room. This has been checked on the following rooms and floors:

- [x] WEH-7500
- [x] SC-LL001A (on the EV floor)
- [x] PH-C1
- [x] SC-LL900 (on LL floor)
- [] GHC-3
- [] SC-EV

Check that nonsense codes don't work
- [] WWW
- [] WEH-999
- [] WEH-7500-9
- [] GHC-
- [] WEH--

**Test Configuration**:

<!-- Please remove sections that are not relevant. -->

- Node.js version: 18
- Desktop/Mobile: Macbook Air M2
- OS: MacOS Sonoma
- Browser: Safari

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
