### PR TITLE
fix search ordering

### DIFF
--- a/src/app/api/events/search/route.ts
+++ b/src/app/api/events/search/route.ts
@@ -16,6 +16,10 @@ async function searchEvents(query: string) {
               wildcard: '*',
             },
           },
+          sort: {
+            score: { $meta: 'searchScore' },
+            date: -1,
+          },
         },
       },
     ],


### PR DESCRIPTION
I love the template but this is literally one line change

Changes the ordering of the search results to be sorted by date (latest first) secondarily to mongo search proximity.  
Tested locally (arc, macos).  No real other impact on the rest of the codebase