### PR TITLE
Selects a building when any point in polygon is clicked

### DIFF
--- a/src/lib/features/uiSlice.ts
+++ b/src/lib/features/uiSlice.ts
@@ -46,6 +46,9 @@ const uiSlice = createSlice({
       state.selectedBuilding = null;
       state.isSearchOpen = false;
     },
+    deselectRoom(state) {
+      state.selectedRoom = null;
+    },
     setFocusedFloor(state, action: PayloadAction<Floor | null>) {
       state.focusedFloor = action.payload;
       state.isFloorPlanRendered = false;
@@ -92,6 +95,7 @@ export const getIsCardOpen = (state: UIState) => {
 export const {
   selectRoom,
   selectBuilding,
+  deselectRoom,
   deselectBuilding,
   setFocusedFloor,
   setIsSearchOpen,

--- a/src/util/geometry.ts
+++ b/src/util/geometry.ts
@@ -3,7 +3,7 @@
  */
 import { Coordinate } from 'mapkit-react';
 
-import { AbsoluteCoordinate } from './types';
+import { AbsoluteCoordinate } from '../types';
 
 // The number of meters in a degree.
 // Values computed for the Pittsburgh region using https://stackoverflow.com/a/51765950/4652564


### PR DESCRIPTION
Doesn't select a room only when the roundel is clicked. When zoomed in to floor plan view, doesn't select building.

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes #[REPLACE WITH ISSUE NUMBER]

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

**Test Configuration**:

<!-- Please remove sections that are not relevant. -->

- Node.js version:
- Python version:
- Desktop/Mobile:
- OS:
- Browser:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
